### PR TITLE
Desktop nav

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -6,11 +6,16 @@ const NavWrapper = styled.div`
 `;
 
 const VertNav = styled.div`
-    position: absolute;
     right: 5.5vw;
     top:190px;
     z-index:100;
     padding:1rem 0rem;
+    background-color: ${props => props.isSection ? 'rgba(99, 55, 84, 1)' : 'transparent'};
+    border-radius: ${props => props.isSection ? '25px' : 'none'};
+    box-shadow: ${props => props.isSection ? '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' : 'none'};
+    position: ${props => props.isSection ? 'absolute' : 'absolute'};
+    margin-right: 0.1rem;
+    padding-right: 1.2rem;
 `;
 
 const Tab = styled.a`
@@ -31,9 +36,8 @@ const Tab = styled.a`
 
 const NavText = styled.div`
     font-style: normal;
-    margin-right:2rem;
+    margin-right:1.5rem;
     text-transform: uppercase;
-
 `;
 
 const Bullet = styled.span`
@@ -45,11 +49,11 @@ const Bullet = styled.span`
     margin-top: 0.38rem;
 `
 
-const NavBar = () => {
+const NavBar = ({isSection}) => {
     const [current, setCurrent] = useState("/#");
     return(
         <NavWrapper>
-            <VertNav>
+            <VertNav isSection={isSection}>
             {sections.map((section, index) => (
                 <Tab current = {current == section.url} onClick = {()=>setCurrent(section.url)} key={index}>
                      <Bullet></Bullet> <NavText>{section.title} {current==section.url}</NavText>  

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -16,6 +16,7 @@ const Home = () => {
     return (
         <HomeContainer>
             <Letter/>
+            <NavBar/>
             <Credits/>
         </HomeContainer>
     );

--- a/src/containers/Section.js
+++ b/src/containers/Section.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import NavBar from '../components/NavBar';
 
 const SectionWrapper = styled.div`
     height: 100vh;
@@ -10,7 +11,9 @@ const SectionWrapper = styled.div`
 const Section = () => {
 
     return (
-        <SectionWrapper></SectionWrapper>
+        <SectionWrapper>
+            <NavBar isSection/>
+        </SectionWrapper>
     );
 };
 


### PR DESCRIPTION
I made the desktop nav bar for the home page so that it looks like this: 
![Screenshot 2023-02-10 at 2 51 11 PM](https://user-images.githubusercontent.com/86814080/218185021-7287293b-36f0-41f7-a848-5cca1e6f40e8.jpg)
The color of the texts changes color to pink when you hover over a different section page. The current section you are on is bolded and pink. The nav bar position is absolute so it does not stay on the page as you scroll. 

The desktop nav bar for individual section pages (not home) looks a little bit different. It has a background color and box shadow around the box. The position is supposed to be sticky but I'm not sure if it does that. This is how the section nav bar looks like: 
![Screenshot 2023-02-10 at 2 54 55 PM](https://user-images.githubusercontent.com/86814080/218185592-4e3a371d-e1e6-45be-a59f-878c356ce642.jpg)

Closes #1 